### PR TITLE
[footnote-reference-popover] Add `data-ignore` attribute

### DIFF
--- a/packages/footnote-reference-popover/README.md
+++ b/packages/footnote-reference-popover/README.md
@@ -42,11 +42,13 @@ Using the Popover feature. ([Can I use...](https://caniuse.com/wf-popover))
   footnoteReferencePopover(document.querySelectorAll('.js-footnote-reference-popover')); // `getElementById()` or `getElementsByClassName()` or `getElementsByTagName()` or `querySelector()` or `querySelectorAll()`
 </script>
 
-<a class="js-footnote-reference-popover" href="#footnote-1">[1]</a>
+<a class="js-footnote-reference-popover" href="#fn-1">[1]</a>
 
 <a
   class="js-footnote-reference-popover"
-  href="#footnote-2"
+  id="fnref-2"
+  href="#fn-2"
+  data-ignore=".backref"
   data-popover-label="Note"
   data-popover-class="my-popover"
   data-popover-hide-text="Popover Close"
@@ -58,10 +60,9 @@ Using the Popover feature. ([Can I use...](https://caniuse.com/wf-popover))
   >[2]</a
 >
 
-<ul>
-  <li id="footnote-1">Footnote text.</li>
-  <li id="footnote-2">Footnote text. <a href="#">link</a> <code>code</code> <em>emphasis</em></li>
-</ul>
+<p id="fn-1">Footnote1 text.</p>
+
+<p id="fn-2">Footnote2 <a href="#">link</a> text. <a href="#fnref-2" class="backref">↩ Back</a></p>
 ```
 
 \* **`@w0s/shadow-append-css` is no longer required since version 7.3**
@@ -70,7 +71,9 @@ Using the Popover feature. ([Can I use...](https://caniuse.com/wf-popover))
 
 <dl>
 <dt><code>href</code> [required]</dt>
-<dd>URL hash value of the element that contains the content to be displayed in the popover. (e.g. <code>#footnote-1</code> )</dd>
+<dd>URL hash value of the element that contains the content to be displayed in the popover. (e.g. <code>#fn-1</code> )</dd>
+<dt><code>data-ignore</code> [optional]</dt>
+<dd>Selectors string for elements to ignore from the popover. For example, if a footnote contains a “Back” link, it should not be displayed in the popover.</dd>
 <dt><code>data-popover-label</code> [optional]</dt>
 <dd>Label to be set on popover (<code>aria-label</code> attribute value).</dd>
 <dt><code>data-popover-class</code> [optional]</dt>
@@ -96,15 +99,13 @@ The popover markup looks like this.
 ```html
 <a
   class="js-footnote-reference-popover"
-  href="#footnote"
+  href="#fn"
   data-popover-label="Note"
   data-popover-class="my-popover"
   data-popover-hide-text="Popover Close"
   data-popover-hide-image-src="./popover-close.svg"
   data-popover-hide-image-width="18"
   data-popover-hide-image-height="18"
-  data-mouseenter-delay="1000"
-  data-mouseleave-delay="1000"
   >[1]</a
 >
 

--- a/packages/footnote-reference-popover/demo/index.html
+++ b/packages/footnote-reference-popover/demo/index.html
@@ -4,12 +4,6 @@
 		<meta name="viewport" content="width=device-width,initial-scale=1" />
 		<title>`footnote-reference-popover` Demo</title>
 		<style>
-			.footnotes {
-				margin-block-start: 5em;
-				border-block-start: 1px solid #ccc;
-				padding-block-start: 1em;
-			}
-
 			.my-popover {
 				--popover-hide-button-image-size: 18px;
 				--popover-hide-button-padding: 10px;
@@ -46,6 +40,25 @@
 					background-color: #eee;
 				}
 			}
+
+			.footnotes {
+				display: block grid;
+				grid-template-columns: auto 1fr;
+				gap: 1em 0.5em;
+				margin-block-start: 5em;
+				border-block-start: 1px solid #ccc;
+				padding-block-start: 1em;
+			}
+
+			.footnote {
+				display: block grid;
+				grid-template-columns: subgrid;
+				grid-column: 1 / -1;
+
+				& p {
+					margin: unset;
+				}
+			}
 		</style>
 		<script type="importmap">
 			{
@@ -66,10 +79,10 @@
 		<section>
 			<h2>Required attributes only</h2>
 
-			<pre><code>&lt;a class="js-footnote-reference-popover" href="#footnote-1"&gt;[1]&lt;/a&gt;</code></pre>
+			<pre><code>&lt;a class="js-footnote-reference-popover" href="#fn-1"&gt;[1]&lt;/a&gt;</code></pre>
 
 			<p>
-				text text <sup><a class="js-footnote-reference-popover" href="#footnote-1">[1]</a></sup> text text
+				text text <sup><a class="js-footnote-reference-popover" href="#fn-1">[1]</a></sup> text
 			</p>
 		</section>
 
@@ -77,16 +90,18 @@
 			<h2>All attributes &amp; Style customization</h2>
 
 			<pre><code>&lt;a
-  class="js-footnote-reference-popover"
-  href="#footnote-2"
-  data-popover-label="Note"
-  data-popover-class="my-popover"
-  data-popover-hide-text="Popover Close"
-  data-popover-hide-image-src="./popover-close.svg"
-  data-popover-hide-image-width="18"
-  data-popover-hide-image-height="18"
-  data-mouseenter-delay="1000"
-  data-mouseleave-delay="1000"
+	class="js-footnote-reference-popover"
+	id="fnref-2"
+	href="#fn-2"
+	data-ignore=".backref"
+	data-popover-label="Note"
+	data-popover-class="my-popover"
+	data-popover-hide-text="Popover Close"
+	data-popover-hide-image-src="./popover-close.svg"
+	data-popover-hide-image-width="18"
+	data-popover-hide-image-height="18"
+	data-mouseenter-delay="1000"
+	data-mouseleave-delay="1000"
 &gt;[2]&lt;/a&gt;</code></pre>
 
 			<p>
@@ -94,7 +109,9 @@
 				<sup
 					><a
 						class="js-footnote-reference-popover"
-						href="#footnote-2"
+						id="fnref-2"
+						href="#fn-2"
+						data-ignore=".backref"
 						data-popover-label="Note"
 						data-popover-class="my-popover"
 						data-popover-hide-text="Popover Close"
@@ -106,24 +123,23 @@
 						>[2]</a
 					></sup
 				>
-				text text
+				text
 			</p>
 		</section>
 
-		<ul class="footnotes">
-			<li>
-				[1]
-				<span id="footnote-1">footnotes1 <a href="https://example.com/1">Link1</a></span>
-			</li>
-			<li>
-				[2]
-				<span id="footnote-2"
-					>footnotes2 text text <a href="https://example.com/1" id="footnote2-link1">Link1</a> text
-					<a href="https://example.com/1" id="footnote2-link2">Link2</a> text text text text text text text text text text text text text text text text text
-					text text text text text text text text text text text text text text text text text text text text text text text text text text text text text text
-					text text text text text text text text text text text text text text text text text text text text text</span
-				>
-			</li>
-		</ul>
+		<div class="footnotes">
+			<div class="footnote">
+				<span class="footnote__no">1.</span>
+				<p id="fn-1">Footnote1 text.</p>
+			</div>
+			<div class="footnote">
+				<span class="footnote__no">2.</span>
+				<p id="fn-2">
+					Footnote2 <a href="https://example.com/1" id="footnote2-link1">Link1</a> text text text text text text text text text text text text text text text
+					text text text text text text text text text text text text text text text.
+					<a href="#fnref-2" class="backref">↩ Back</a>
+				</p>
+			</div>
+		</div>
 	</body>
 </html>

--- a/packages/footnote-reference-popover/src/attribute/Ignore.test.ts
+++ b/packages/footnote-reference-popover/src/attribute/Ignore.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from '@jest/globals';
+import Ignore from './Ignore.ts';
+
+test('no attribute', () => {
+	expect(new Ignore(undefined).selectors).toBeUndefined();
+});
+
+test('selectors', () => {
+	expect(new Ignore('.foo').selectors).toBe('.foo');
+});

--- a/packages/footnote-reference-popover/src/attribute/Ignore.ts
+++ b/packages/footnote-reference-popover/src/attribute/Ignore.ts
@@ -1,0 +1,21 @@
+/**
+ * `data-ignore` attribute
+ */
+export default class {
+	readonly #selectors: string | undefined;
+
+	/**
+	 * @param value - Attribute value
+	 */
+	constructor(value: string | null | undefined) {
+		if (value === null || value === undefined) {
+			return;
+		}
+
+		this.#selectors = value;
+	}
+
+	get selectors(): string | undefined {
+		return this.#selectors;
+	}
+}

--- a/packages/footnote-reference-popover/src/custom-element/Popover.test.ts
+++ b/packages/footnote-reference-popover/src/custom-element/Popover.test.ts
@@ -13,6 +13,16 @@ describe('slot', () => {
 		expect(spanElement?.textContent).toBe('text');
 		expect(spanElement?.id).toBe('');
 	});
+
+	test('ignore-selectors', () => {
+		document.body.innerHTML = `<x-popover ignore-selectors=".foo"><span class="foo"></span><span class="bar"></span></x-popover>`;
+
+		const popoverElement = document.querySelector<PopoverElement>(POPOVER_ELEMENT_NAME)!;
+
+		expect(popoverElement.ignoreSelectors).toBe('.foo');
+		expect(popoverElement.querySelector('.foo')).toBeNull();
+		expect(popoverElement.querySelector('.bar')).not.toBeNull();
+	});
 });
 
 describe('attributes', () => {

--- a/packages/footnote-reference-popover/src/custom-element/Popover.ts
+++ b/packages/footnote-reference-popover/src/custom-element/Popover.ts
@@ -15,6 +15,8 @@ export default class extends HTMLElement {
 
 	readonly #lastFocusableElement: HTMLElement;
 
+	#ignoreSelectors: string | null = null;
+
 	readonly #hideButtonElement: HTMLButtonElement;
 
 	readonly #hideButtonTextElement: HTMLSpanElement;
@@ -34,7 +36,7 @@ export default class extends HTMLElement {
 	#state: State | undefined; // test で使用（JSDOM が `:popover-open` 疑似クラスに対応したら不要になる https://github.com/jsdom/jsdom/issues/3721 ）
 
 	static get observedAttributes(): string[] {
-		return ['hide-text', 'hide-image-src', 'hide-image-width', 'hide-image-height'];
+		return ['ignore-selectors', 'hide-text', 'hide-image-src', 'hide-image-width', 'hide-image-height'];
 	}
 
 	constructor() {
@@ -93,11 +95,17 @@ export default class extends HTMLElement {
 		this.popover = '';
 		this.#hideButtonElement.popoverTargetElement = this;
 
-		/* コピー元の HTML 中に `id` 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
 		const hostElement = this.shadowRoot?.host;
-		if (hostElement !== undefined) {
-			hostElement.querySelectorAll('[id]').forEach((element) => {
-				element.removeAttribute('id');
+
+		/* コピー元の HTML 中に `id` 属性が設定されていた場合、ページ中に ID が重複してしまうのを防ぐ */
+		hostElement?.querySelectorAll('[id]').forEach((element) => {
+			element.removeAttribute('id');
+		});
+
+		/* 除外要素 */
+		if (this.#ignoreSelectors !== null) {
+			hostElement?.querySelectorAll(this.#ignoreSelectors).forEach((element) => {
+				element.remove();
 			});
 		}
 
@@ -120,6 +128,10 @@ export default class extends HTMLElement {
 
 	attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
 		switch (name) {
+			case 'ignore-selectors': {
+				this.ignoreSelectors = newValue;
+				break;
+			}
 			case 'hide-text': {
 				this.hideText = newValue;
 				break;
@@ -140,7 +152,15 @@ export default class extends HTMLElement {
 		}
 	}
 
-	get hideText(): string {
+	get ignoreSelectors(): string | null {
+		return this.#ignoreSelectors;
+	}
+
+	set ignoreSelectors(value: string | null) {
+		this.#ignoreSelectors = value;
+	}
+
+	get hideText(): string | null {
 		return this.#hideText;
 	}
 
@@ -232,7 +252,7 @@ export default class extends HTMLElement {
 	}
 
 	/**
-	 * ポップオーバーの表示／非表示状態が変化したの処理
+	 * ポップオーバーの表示／非表示状態が変化したときの処理
 	 *
 	 * @param ev - Event
 	 */

--- a/packages/footnote-reference-popover/src/footnoteReferencePopover.test.ts
+++ b/packages/footnote-reference-popover/src/footnoteReferencePopover.test.ts
@@ -9,6 +9,59 @@ const sleep = (ms: number) =>
 		setTimeout(callback, ms);
 	});
 
+describe('attribute', () => {
+	describe('Required attributes only', () => {
+		beforeAll(() => {
+			document.body.innerHTML = `
+<a href="#footnote"></a>
+<p id="footnote"></p>
+`;
+
+			footnoteReferencePopover(document.querySelector('a')!);
+		});
+
+		test('trigger', () => {
+			expect(document.querySelector('a')?.getAttribute('role')).toBe('button');
+		});
+
+		test('popover', () => {
+			document.querySelector('a')?.dispatchEvent(new UIEvent('click'));
+
+			const popoverElement = document.querySelector<PopoverElement>(POPOVER_ELEMENT_NAME);
+			expect(popoverElement?.popover).toBe('');
+			expect(popoverElement?.getAttribute('class')).toBeNull();
+			expect(popoverElement?.getAttribute('aria-label')).toBeNull();
+		});
+	});
+
+	describe('All attributes', () => {
+		beforeAll(() => {
+			document.body.innerHTML = `
+<a
+	href="#footnote"
+	data-popover-label="Note"
+	data-popover-class="my-popover"></a>
+<p id="footnote"></p>
+`;
+
+			footnoteReferencePopover(document.querySelector('a')!);
+		});
+
+		test('trigger', () => {
+			expect(document.querySelector('a')?.getAttribute('role')).toBe('button');
+		});
+
+		test('popover', () => {
+			document.querySelector('a')?.dispatchEvent(new UIEvent('click'));
+
+			const popoverElement = document.querySelector<PopoverElement>(POPOVER_ELEMENT_NAME);
+			expect(popoverElement?.popover).toBe('');
+			expect(popoverElement?.getAttribute('class')).toBe('my-popover');
+			expect(popoverElement?.getAttribute('aria-label')).toBe('Note');
+		});
+	});
+});
+
 describe('trigger click event', () => {
 	beforeAll(() => {
 		document.body.innerHTML = `
@@ -17,10 +70,6 @@ describe('trigger click event', () => {
 `;
 
 		footnoteReferencePopover(document.querySelector('a')!);
-	});
-
-	test('init', () => {
-		expect(document.querySelector('a')?.getAttribute('role')).toBe('button');
 	});
 
 	test('click', () => {

--- a/packages/footnote-reference-popover/src/footnoteReferencePopover.ts
+++ b/packages/footnote-reference-popover/src/footnoteReferencePopover.ts
@@ -1,4 +1,5 @@
 import FootnoteElementAttribute from './attribute/FootnoteElement.ts';
+import IgnoreAttribute from './attribute/Ignore.ts';
 import MouseenterAttribute from './attribute/Mouseenter.ts';
 import MouseleaveAttribute from './attribute/Mouseleave.ts';
 import PopoverClassAttribute from './attribute/PopoverClass.ts';
@@ -88,6 +89,7 @@ export const hide = (eventType: string, popover: PopoverElement): void => {
 export default (thisElement: HTMLAnchorElement): void => {
 	const { href: hrefAttributeValue } = thisElement;
 	const {
+		ignore: ignoreAttributeValue,
 		popoverLabel: popoverLabelAttributeValue,
 		popoverClass: popoverClassAttributeValue,
 		popoverHideText: popoverHideTextAttributeValue,
@@ -99,6 +101,7 @@ export default (thisElement: HTMLAnchorElement): void => {
 	} = thisElement.dataset;
 
 	const footnoteElement = new FootnoteElementAttribute(hrefAttributeValue);
+	const ignore = new IgnoreAttribute(ignoreAttributeValue);
 	const popoverLabel = new PopoverLabelAttribute(popoverLabelAttributeValue);
 	const popoverClass = new PopoverClassAttribute(popoverClassAttributeValue);
 	const popoverHide = new PopoverHideAttribute({
@@ -118,6 +121,7 @@ export default (thisElement: HTMLAnchorElement): void => {
 	if (popoverClass.name !== undefined) {
 		popoverElement.className = popoverClass.name;
 	}
+	popoverElement.ignoreSelectors = ignore.selectors ?? null;
 	popoverElement.ariaLabel = popoverLabel.text ?? null;
 	popoverElement.hideText = popoverHide.text ?? null;
 	popoverElement.hideImageSrc = popoverHide.imageSrc ?? null;


### PR DESCRIPTION
Added a feature to specify elements to ignore from popovers.

For example, if a footnote contains a “Back” link, it should not be displayed in the popover.